### PR TITLE
fixed Update-MrkOrgAdmin.ps1

### DIFF
--- a/PSMeraki/Public/Update-MrkOrgAdmin.ps1
+++ b/PSMeraki/Public/Update-MrkOrgAdmin.ps1
@@ -1,37 +1,61 @@
 function Update-MrkOrgAdmin {
     <#
     .SYNOPSIS
-    Creates new dashboard Admin 
+    Updates an existing dashboard Administrator
     .DESCRIPTION
     .EXAMPLE
-    Update-MrkOrgAdmin -Name 'Piet Test' -email 'piets@Test.com' -orgAccess 'read-only'
+
+    Update-MrkOrgAdmin -email 'piets@Test.com' -orgAccess 'read-only'
+    grants read-only access on everyting on your dashboard.
+
+    Update-MrkOrgAdmin -email 'piets@Test.com' -tag 'YOURTAG' -tagaccess 'Full'
+    Grants access to all objects tagged YOURTAG
+
     .PARAMETER OrgId 
     defaults to Get-MrkFirstOrgID, for admins who maintain multiple organizations, OrgID can be specified
-    .PARAMETER Name
-    Name of the dashboard admin 
     .PARAMETER email
     email address of the dashboard admin 
     .PARAMETER orgAccess
     Access for the admin either 'full' 'read-only' or 'none'. If its 'none' tags specify the permissions. 
-    .PARAMETER tags
-    see rest api diucs for details.
+    .PARAMETER tag
+    The tag of the objects you want to change access on.
+    .PARAMETER tagaccess
+    Access for the admin either 'full' 'read-only' or 'none' on the obects specified in tag.
     .NOTES
-    This function is untested
+
     #>
     [CmdletBinding()]
+    
     Param (
         [Parameter()][String]$OrgId = (Get-MrkFirstOrgID),
-        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][String]$Name,
-        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][String]$email,
-        [Parameter(Mandatory)][ValidateSet('full','read-only','none')][String]$orgAccess,
-        [Parameter()][ValidateNotNullOrEmpty()][String]$tags
+        #[Parameter(Mandatory)][ValidateNotNullOrEmpty()][String]$Name,
+        [Parameter()][ValidateNotNullOrEmpty()][String]$email,
+        [Parameter()][ValidateSet('full','read-only','none')][String]$orgAccess,
+        [Parameter()][ValidateNotNullOrEmpty()][String]$tag,
+        [Parameter()][ValidateSet('full','read-only','none')][String]$tagAccess
     )
-    $body  = @{
-        "name" = $Name
+
+    
+ $tags=@([pscustomobject]@{tag = $tag; access = $tagaccess})
+ $networks=
+
+    
+    $global:body  = @{
         "email" = $email
-        "orgAccess" = $orgAccess
-        "Tags" = $tags
+        "Orgaccess" = $orgAccess
+        "tags" =   $tags
     }
-    $request = Invoke-MrkRestMethod -Method POST -ResourceID ('/organizations/' + $OrgId + '/admins/') -Body $body  
+
+
+
+    $id= get-mrkorgadmins -OrgId $Orgid |where{$_.email -like $email}
+    $request = Invoke-MrkRestMethod -Method PUT -ResourceID ('/organizations/' + $OrgId + '/admins/'+ $id.id ) -Body $body  
     return $request
 }
+
+
+
+
+
+
+


### PR DESCRIPTION
De tags parmater is een array in een array daarvoor heb ik er een pscustomobject anders ging de convertto-json niet goed.
Omdat $orgaccess op een ander niveau rechten geeft heb ik een nieuwe parameter $tagaccess gemaakt.
en omdat het een het ander niet uitsluit heb ik de parameters niet mandatory gemaakt.